### PR TITLE
Fixed RD-15322: Report user-visible errors to caller instead of retrying

### DIFF
--- a/src/main/scala/com/rawlabs/das/server/TableServiceGrpcImpl.scala
+++ b/src/main/scala/com/rawlabs/das/server/TableServiceGrpcImpl.scala
@@ -12,11 +12,12 @@
 
 package com.rawlabs.das.server
 
-import com.rawlabs.protocol.das.{Row, Rows, SortKeys}
+import com.rawlabs.das.sdk.{DASSdk, DASSdkUnsupportedException, DASTable}
+import com.rawlabs.protocol.das._
 import com.rawlabs.protocol.das.services._
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.Context
 import io.grpc.stub.StreamObserver
+import io.grpc.{Context, Status}
 
 import java.io.Closeable
 import scala.collection.JavaConverters._
@@ -24,6 +25,8 @@ import scala.collection.mutable
 
 /**
  * Implementation of the gRPC service for handling table-related operations.
+ * Errors are returned to the client as gRPC errors. Those tagged as `INVALID_ARGUMENT` are errors that go
+ * to the client, while others are internal errors.
  *
  * @param provider Provides access to DAS (Data Access Service) instances.
  * @param cache Cache for storing query results.
@@ -35,7 +38,7 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
   /**
    * Retrieves table definitions based on the DAS ID provided in the request.
    *
-   * @param request The request containing the DAS ID.
+   * @param request          The request containing the DAS ID.
    * @param responseObserver The observer to send responses.
    */
   override def getDefinitions(
@@ -43,57 +46,47 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
       responseObserver: StreamObserver[GetDefinitionsResponse]
   ): Unit = {
     logger.debug(s"Fetching table definitions for DAS ID: ${request.getDasId}")
-    val tableDefinitions = provider.getDAS(request.getDasId).tableDefinitions
-    val response = GetDefinitionsResponse.newBuilder().addAllDefinitions(tableDefinitions.asJava).build()
-    responseObserver.onNext(response)
-    responseObserver.onCompleted()
-    logger.debug("Table definitions sent successfully.")
+    withDAS(request.getDasId, responseObserver) { das =>
+      val tableDefinitions = das.tableDefinitions
+      val response = GetDefinitionsResponse.newBuilder().addAllDefinitions(tableDefinitions.asJava).build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+      logger.debug("Table definitions sent successfully.")
+    }
   }
 
   /**
    * Retrieves the size (rows and bytes) of a table based on the table ID provided in the request.
    *
-   * @param request The request containing the table ID.
+   * @param request          The request containing the table ID.
    * @param responseObserver The observer to send responses.
    */
   override def getRelSize(request: GetRelSizeRequest, responseObserver: StreamObserver[GetRelSizeResponse]): Unit = {
     logger.debug(s"Fetching table size for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
-        val (rows, bytes) = table.getRelSize(request.getQualsList.asScala, request.getColumnsList.asScala)
-        val response = GetRelSizeResponse.newBuilder().setRows(rows).setBytes(bytes).build()
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-        logger.debug(s"Table size (rows: $rows, bytes: $bytes) sent successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      val (rows, bytes) = table.getRelSize(request.getQualsList.asScala, request.getColumnsList.asScala)
+      val response = GetRelSizeResponse.newBuilder().setRows(rows).setBytes(bytes).build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+      logger.debug(s"Table size (rows: $rows, bytes: $bytes) sent successfully.")
     }
   }
 
   /**
    * Checks if the table can be sorted using the provided sort keys.
    *
-   * @param request The request containing the sort keys.
+   * @param request          The request containing the sort keys.
    * @param responseObserver The observer to send responses.
    */
   override def canSort(request: CanSortRequest, responseObserver: StreamObserver[CanSortResponse]): Unit = {
     logger.debug(s"Checking if table can be sorted for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
-        val sortKeys = table.canSort(request.getSortKeys.getSortKeysList.asScala)
-        val response =
-          CanSortResponse.newBuilder().setSortKeys(SortKeys.newBuilder().addAllSortKeys(sortKeys.asJava)).build()
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-        logger.debug("Sort capability information sent successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      val sortKeys = table.canSort(request.getSortKeys.getSortKeysList.asScala)
+      val response =
+        CanSortResponse.newBuilder().setSortKeys(SortKeys.newBuilder().addAllSortKeys(sortKeys.asJava)).build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+      logger.debug("Sort capability information sent successfully.")
     }
   }
 
@@ -105,23 +98,17 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
    */
   override def getPathKeys(request: GetPathKeysRequest, responseObserver: StreamObserver[GetPathKeysResponse]): Unit = {
     logger.debug(s"Fetching path keys for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
-        val pathKeys = table.getPathKeys
-        val response = GetPathKeysResponse
-          .newBuilder()
-          .addAllPathKeys(pathKeys.map {
-            case (keys, rows) => PathKey.newBuilder().addAllKeyColumns(keys.asJava).setExpectedRows(rows).build()
-          }.asJava)
-          .build()
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-        logger.debug("Path keys information sent successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      val pathKeys = table.getPathKeys
+      val response = GetPathKeysResponse
+        .newBuilder()
+        .addAllPathKeys(pathKeys.map {
+          case (keys, rows) => PathKey.newBuilder().addAllKeyColumns(keys.asJava).setExpectedRows(rows).build()
+        }.asJava)
+        .build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+      logger.debug("Path keys information sent successfully.")
     }
   }
 
@@ -133,10 +120,8 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
    */
   override def explain(request: ExplainRequest, responseObserver: StreamObserver[ExplainResponse]): Unit = {
     logger.debug(s"Explaining query for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         val explanation = table.explain(
           request.getQualsList.asScala,
           request.getColumnsList.asScala,
@@ -148,9 +133,13 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
         responseObserver.onNext(response)
         responseObserver.onCompleted()
         logger.debug("Query explanation sent successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+      } catch {
+        case t: Throwable =>
+          logger.error("Error explaining query", t)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error explaining query").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
@@ -162,67 +151,74 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
    */
   override def execute(request: ExecuteRequest, responseObserver: StreamObserver[Rows]): Unit = {
     logger.debug(s"Executing query for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
-        def task(): Iterator[Rows] with Closeable = {
-          logger.debug(s"Executing query for Table ID: ${request.getTableId.getName}, Plan ID: ${request.getPlanId}")
-          val result = table.execute(
-            request.getQualsList.asScala,
-            request.getColumnsList.asScala,
-            if (request.hasSortKeys) Some(request.getSortKeys.getSortKeysList.asScala) else None,
-            if (request.hasLimit) Some(request.getLimit) else None
-          )
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      def runQuery(): Iterator[Rows] with Closeable = {
+        logger.debug(
+          s"Executing query for Table ID: ${request.getTableId.getName}, Plan ID: ${request.getPlanId}"
+        )
+        val result = table.execute(
+          request.getQualsList.asScala,
+          request.getColumnsList.asScala,
+          if (request.hasSortKeys) Some(request.getSortKeys.getSortKeysList.asScala) else None,
+          if (request.hasLimit) Some(request.getLimit) else None
+        )
 
-          val MAX_CHUNK_SIZE = 100
-          logger.debug(
-            s"Creating iterator (chunk size $MAX_CHUNK_SIZE rows) for query execution for Table ID: ${request.getTableId.getName}, Plan ID: ${request.getPlanId}"
-          )
-          // Wrap the result processing logic in the iterator
-          new ChunksIterator(request, result, MAX_CHUNK_SIZE)
-        }
-
+        val MAX_CHUNK_SIZE = 100
+        logger.debug(
+          s"Creating iterator (chunk size $MAX_CHUNK_SIZE rows) for query execution for Table ID: ${request.getTableId.getName}, Plan ID: ${request.getPlanId}"
+        )
         // Wrap the result processing logic in the iterator
-        val it = {
-          DASChunksCache.get(request) match {
-            case Some(cachedChunks) =>
-              logger.debug(s"Using cached chunks for Table ID: ${request.getTableId.getName}")
-              val cachedChunksIterator = cachedChunks.iterator
-              new Iterator[Rows] with Closeable {
-                override def hasNext: Boolean = cachedChunksIterator.hasNext
+        new ChunksIterator(request, result, MAX_CHUNK_SIZE)
+      }
 
-                override def next(): Rows = cachedChunksIterator.next()
+      // Wrap the result processing logic in the iterator
+      val it = {
+        DASChunksCache.get(request) match {
+          case Some(cachedChunks) =>
+            logger.debug(s"Using cached chunks for Table ID: ${request.getTableId.getName}")
+            val cachedChunksIterator = cachedChunks.iterator
+            new Iterator[Rows] with Closeable {
+              override def hasNext: Boolean = cachedChunksIterator.hasNext
 
-                override def close(): Unit = {}
-              }
-            case None =>
-              logger.debug(s"Cache miss for Table ID: ${request.getTableId.getName}")
-              task()
-          }
-        }
+              override def next(): Rows = cachedChunksIterator.next()
 
-        val context = Context.current()
-        try {
-          it.foreach { rows =>
-            if (context.isCancelled) {
-              logger.warn("Context cancelled during query execution. Closing reader.")
-              return
+              override def close(): Unit = {}
             }
-            responseObserver.onNext(rows)
-          }
-          logger.debug("Query execution completed successfully.")
-          responseObserver.onCompleted()
-        } catch {
-          case ex: Exception =>
-            logger.error("Error occurred during query execution.", ex)
-            responseObserver.onError(ex)
-        } finally {
-          it.close()
+          case None =>
+            logger.debug(s"Cache miss for Table ID: ${request.getTableId.getName}")
+            try {
+              runQuery()
+            } catch {
+              case t: Throwable =>
+                logger.error("Error executing query", t)
+                responseObserver.onError(
+                  Status.INVALID_ARGUMENT.withDescription("Error executing query").withCause(t).asRuntimeException()
+                )
+                return
+            }
         }
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+      }
+
+      val context = Context.current()
+      try {
+        it.foreach { rows =>
+          if (context.isCancelled) {
+            logger.warn("Context cancelled during query execution. Closing reader.")
+            return
+          }
+          responseObserver.onNext(rows)
+        }
+        logger.debug("Query execution completed successfully.")
+        responseObserver.onCompleted()
+      } catch {
+        case ex: Exception =>
+          logger.error("Error occurred during query execution.", ex)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error occurred during query execution").asRuntimeException()
+          )
+      } finally {
+        it.close()
+      }
     }
   }
 
@@ -237,22 +233,27 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
       responseObserver: StreamObserver[UniqueColumnResponse]
   ): Unit = {
     logger.debug(s"Fetching unique columns for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         val response = UniqueColumnResponse.newBuilder().setColumn(table.uniqueColumn).build()
         responseObserver.onNext(response)
         responseObserver.onCompleted()
         logger.debug("Unique column information sent successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+      } catch {
+        case t: DASSdkUnsupportedException => responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Unsupported operation").withCause(t).asRuntimeException()
+          )
+        case t: Throwable =>
+          logger.error("Error fetching unique column", t)
+          responseObserver.onError(
+            Status.INTERNAL.withDescription("Error fetching unique column").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
   /**
-   * Modifies the batch size of the specified table.
+   * Returns the modify batch size of the specified table (how many rows can be sent in an update).
    *
    * @param request The request containing table ID.
    * @param responseObserver The observer to send responses.
@@ -261,19 +262,13 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
       request: ModifyBatchSizeRequest,
       responseObserver: StreamObserver[ModifyBatchSizeResponse]
   ): Unit = {
-    logger.debug(s"Modifying batch size for Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
-        val batchSize = table.modifyBatchSize
-        val response = ModifyBatchSizeResponse.newBuilder().setSize(batchSize).build()
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-        logger.debug("Batch size modification completed successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+    logger.debug(s"Returning modify batch size for Table ID: ${request.getTableId.getName}")
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      val batchSize = table.modifyBatchSize
+      val response = ModifyBatchSizeResponse.newBuilder().setSize(batchSize).build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+      logger.debug("Batch size returned successfully.")
     }
   }
 
@@ -285,17 +280,19 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
    */
   override def insert(request: InsertRequest, responseObserver: StreamObserver[InsertResponse]): Unit = {
     logger.debug(s"Inserting row into Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         val row = table.insert(request.getValues)
         responseObserver.onNext(InsertResponse.newBuilder().setRow(row).build())
         responseObserver.onCompleted()
         logger.debug("Row inserted successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+      } catch {
+        case t: Throwable =>
+          logger.error("Error inserting row", t)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error inserting row").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
@@ -307,64 +304,98 @@ class TableServiceGrpcImpl(provider: DASSdkManager, cache: DASResultCache)
    */
   override def bulkInsert(request: BulkInsertRequest, responseObserver: StreamObserver[BulkInsertResponse]): Unit = {
     logger.debug(s"Performing bulk insert into Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         val rows = table.bulkInsert(request.getValuesList.asScala)
         responseObserver.onNext(BulkInsertResponse.newBuilder().addAllRows(rows.asJava).build())
         responseObserver.onCompleted()
         logger.debug("Bulk insert completed successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+      } catch {
+        case t: Throwable =>
+          logger.error("Error inserting rows", t)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error inserting rows").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
   /**
-   * Updates rows in the specified table based on the unique columns and new values provided.
+   * Updates a row in the specified table based on the unique column and new values provided.
    *
-   * @param request The request containing the unique columns and new values.
+   * @param request The request containing the unique column and new values.
    * @param responseObserver The observer to send responses.
    */
   override def update(request: UpdateRequest, responseObserver: StreamObserver[UpdateResponse]): Unit = {
-    logger.debug(s"Updating rows in Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    logger.debug(s"Updating row in Table ID: ${request.getTableId.getName}")
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         val newRow = table.update(request.getRowId, request.getNewValues)
         responseObserver.onNext(UpdateResponse.newBuilder().setRow(newRow).build())
         responseObserver.onCompleted()
-        logger.debug("Rows updated successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+        logger.debug("Row updated successfully.")
+      } catch {
+        case t: Throwable =>
+          logger.error("Error updating row", t)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error updating row").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
   /**
-   * Deletes rows from the specified table based on the unique columns provided.
+   * Deletes a row from the specified table based on the unique column provided.
    *
-   * @param request The request containing the unique columns.
+   * @param request The request containing the unique column.
    * @param responseObserver The observer to send responses.
    */
   override def delete(request: DeleteRequest, responseObserver: StreamObserver[DeleteResponse]): Unit = {
-    logger.debug(s"Deleting rows from Table ID: ${request.getTableId.getName}")
-    provider
-      .getDAS(request.getDasId)
-      .getTable(request.getTableId.getName) match {
-      case Some(table) =>
+    logger.debug(s"Deleting row from Table ID: ${request.getTableId.getName}")
+    withTable(request.getDasId, request.getTableId, responseObserver) { table =>
+      try {
         table.delete(request.getRowId)
         responseObserver.onNext(DeleteResponse.getDefaultInstance)
         responseObserver.onCompleted()
-        logger.debug("Rows deleted successfully.")
-      case None =>
-        logger.error(s"Table ${request.getTableId.getName} not found.")
-        responseObserver.onError(new RuntimeException(s"Table ${request.getTableId.getName} not found"))
+        logger.debug("Row deleted successfully.")
+      } catch {
+        case t: Throwable =>
+          logger.error("Error deleting row", t)
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT.withDescription("Error deleting row").withCause(t).asRuntimeException()
+          )
+      }
     }
   }
 
+  private def withDAS(DASId: DASId, responseObserver: StreamObserver[_])(f: DASSdk => Unit): Unit = {
+    provider.getDAS(DASId) match {
+      case None =>
+        // We use 'NOT_FOUND' so that the client doesn't confuse that error with a user-visible error.
+        responseObserver.onError(Status.NOT_FOUND.withDescription("DAS not found").asRuntimeException())
+      case Some(das) => f(das)
+    }
+  }
+
+  private def withTable(DASId: DASId, table: TableId, responseObserver: StreamObserver[_])(
+      f: DASTable => Unit
+  ): Unit = {
+    withDAS(DASId, responseObserver) { das =>
+      val tableName = table.getName
+      das.getTable(tableName) match {
+        case None =>
+          logger.error(s"Table $tableName not found.")
+          // If we're here, the table wasn't found although Postgres thought it was. The DAS was restarted and has now
+          // fewer tables than before. We should return an error to the client.
+          responseObserver.onError(
+            Status.INVALID_ARGUMENT
+              .withDescription(s"Table $tableName not found")
+              .asRuntimeException()
+          )
+        case Some(table) => f(table)
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This goes with https://github.com/raw-labs/multicorn-das/pull/15.

In this changeset, we use StatusCode `INVALID_ARGUMENT` to flag an error that should be advertised to the user. If a call fails with that error, in multicorn we propagate the exception. That patch goes with a symmetric patch in multicorn.

* DAS not found is returned as `NOT_FOUND`.
* Table not found is returned to the user because that would be the Postgres schema contains a table the DAS doesn't contain, which would happen if restarting a DAS leads to a new schema.
* Calls to the backend are occurring after the DAS and the table are found. They're wrapped in a `try/catch` that eventually returns an `INVALID_ARGUMENT` error. This fails if an `INSERT`, `UPDATE` is given a forbidden value (e.g. a string that is too large), if the operation isn't supported by the backend. Also `SELECT` can fail as certain backends wouldn't offer read access to a table.

These code paths were tested using:
* a DASMock table that doesn't support CRUD,
* a custom mock DAS that exposes a table called `events` that does support all operations but fails if provided dates (qualifiers, values) are before year 2000,
* a custom mock DAS which exposes a table that isn't part of its catalog eventually.

Then all these queries are run with a DAS server up, or down then restarted during the retries.

# Execute
```sql
SELECT * FROM test.events WHERE date > DATE '1922-03-02';
```
retries if needed and fails because the filter is rejected.
```
ERROR:  Error in python: _MultiThreadedRendezvous
DETAIL:  <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Invalid date: year: 1922
month: 3
day: 2
 (only > 2000 supported)"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:38:41.660197+01:00", grpc_status:3, grpc_message:"Invalid date: year: 1922\nmonth: 3\nday: 2\n (only > 2000 supported)"}"
>
```

```sql
SELECT * FROM test.events WHERE date > DATE '2022-03-02';
```
retries if needed and runs successfully.
```
WARNING:  Error in table_service.UniqueColumns for table name: "events"
: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.NOT_FOUND
        details = "DAS not found"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:55:19.312844+01:00", grpc_status:5, grpc_message:"DAS not found"}"
>
 event  |    date    
--------+------------
 event3 | 2023-01-01
 event4 | 2024-01-01
```

```sql
SELECT * FROM test.vanished ;
```
retries if needed and fails because the table isn't found. (This can happen if restarting a DAS and it lost a table.)
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Table vanished not found"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:58:20.208856+01:00", grpc_status:3, grpc_message:"Table vanished not found"}"
>
```
# Insert
```
INSERT INTO test.small VALUES (101, 'blah');
```
retries if needed and fails because the table doesn't support `INSERT`.
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "unsupported operation"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"unsupported operation", grpc_status:3, created_time:"2025-02-03T14:52:52.834397+01:00"}"
>
```
```sql
INSERT INTO test.events VALUES ('event5', DATE '1922-03-02');
```
retries if needed and fails because the date is wrong.
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Invalid date: year: 1922
month: 3
day: 2
 (only > 2000 supported)"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Invalid date: year: 1922\nmonth: 3\nday: 2\n (only > 2000 supported)", grpc_status:3, created_time:"2025-02-03T14:41:09.959135+01:00"}"
>
```
```sql
INSERT INTO test.events VALUES ('event5', DATE '2022-03-02');
```
retries if needed and runs successfully.
```
WARNING:  Error in table_service.UniqueColumns for table name: "events"
: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.NOT_FOUND
        details = "DAS not found"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:55:19.312844+01:00", grpc_status:5, grpc_message:"DAS not found"}"
>
INSERT 0 1
```

# Update
```sql
UPDATE test.small SET column2 = 'tralala' WHERE column1 = 98;
```
retries if needed and fails because the table doesn't support `UPDATE`.
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "unsupported operation"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"unsupported operation", grpc_status:3, created_time:"2025-02-03T14:53:18.871765+01:00"}"
>
```

```sql
UPDATE test.events SET date = DATE '1928-03-03' WHERE event = 'event1';
```
retries if needed and fails because the date is wrong.
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Invalid date: year: 1928
month: 3
day: 3
 (only > 2000 supported)"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Invalid date: year: 1928\nmonth: 3\nday: 3\n (only > 2000 supported)", grpc_status:3, created_time:"2025-02-03T14:50:38.411487+01:00"}"
>
```
```sql
UPDATE test.events SET date = DATE '2028-03-03' WHERE event = 'event1';
```
retries if needed and runs successfully.
```
WARNING:  Error in table_service.UniqueColumns for table name: "events"
: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.NOT_FOUND
        details = "DAS not found"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:55:19.312844+01:00", grpc_status:5, grpc_message:"DAS not found"}"
>
UPDATE 1
```

# Delete
```sql
DELETE FROM test.small WHERE column1 = 98;
```
retries if needed and fails because the table doesn't support `DELETE`.
```
ERROR:  Error in python: _InactiveRpcError
DETAIL:  <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "unsupported operation"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"unsupported operation", grpc_status:3, created_time:"2025-02-03T14:54:11.536554+01:00"}"
>
```

```sql
DELETE FROM test.events WHERE date = DATE '1921-01-01';
```
retries if needed and fails because the date is wrong.
```
ERROR:  Error in python: _MultiThreadedRendezvous
DETAIL:  <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Invalid date: year: 1921
month: 1
day: 1
 (only > 2000 supported)"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Invalid date: year: 1921\nmonth: 1\nday: 1\n (only > 2000 supported)", grpc_status:3, created_time:"2025-02-03T14:54:34.129372+01:00"}"
>
```

```sql
DELETE FROM test.events WHERE date = DATE '2021-01-01';
```
retries if needed and runs successfully.
```
WARNING:  Error in table_service.UniqueColumns for table name: "events"
: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.NOT_FOUND
        details = "DAS not found"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-02-03T14:55:19.312844+01:00", grpc_status:5, grpc_message:"DAS not found"}"
>
DELETE 1
```