### PR TITLE
Fixed RD-15361: Added akka.license-key config that defaults to $AKKA_LICENSE_KEY

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+akka.license-key=${?AKKA_LICENSE_KEY}
+
 das {
     server {
         port = 50051 # the port the server listens on

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,6 +1,3 @@
-akka {
-  license-key = ""
-}
 raw.das.server {
     builtin {
         1 {


### PR DESCRIPTION
With no AKKA_LICENSE_KEY variable set, it goes to dev mode that stops after 15 minutes. (It doesn't pick the empty string as a key that is wrong.)
```
WARN  akka.actor.ActorSystemImpl - Dev use only. Free keys at https://akka.io/key
```

With a proper AKKA_LICENSE_KEY value, it works.
```
INFO  akka.actor.ActorSystemImpl - License check succeeded for Lightbend user (...). License is valid until (...).
```

With a wrong AKKA_LICENSE_KEY value, the error shows and the DAS immediately stops.
```
ERROR akka.actor.ActorSystemImpl - Invalid key. Free keys at https://akka.io/key
INFO  akka.actor.CoordinatedShutdown - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
Exception in thread "main" java.lang.RuntimeException: Invalid key: Error decoding license key: Invalid base62 length
```