### PR TITLE
Added a "random record" column to the all_types table

### DIFF
--- a/src/test/scala/com/rawlabs/das/mock/DASMock.scala
+++ b/src/test/scala/com/rawlabs/das/mock/DASMock.scala
@@ -241,6 +241,10 @@ class DASMock(options: Map[String, String]) extends DASSdk with StrictLogging {
                     .build())
                   .addAtts(AttrType
                     .newBuilder()
+                    .setName("decimalField")
+                    .setTipe(Type.newBuilder().setDecimal(DecimalType.newBuilder()).build()))
+                  .addAtts(AttrType
+                    .newBuilder()
                     .setName("binaryField")
                     .setTipe(Type.newBuilder().setBinary(BinaryType.newBuilder()).build())
                     .build())

--- a/src/test/scala/com/rawlabs/das/mock/DASMock.scala
+++ b/src/test/scala/com/rawlabs/das/mock/DASMock.scala
@@ -252,6 +252,11 @@ class DASMock(options: Map[String, String]) extends DASSdk with StrictLogging {
                   .build())
               .build())
           .build())
+      .addColumns(ColumnDefinition
+        .newBuilder()
+        .setName("random_record_col")
+        .setType(Type.newBuilder().setRecord(RecordType.newBuilder().build()).build())
+        .build())
       .addColumns(
         ColumnDefinition
           .newBuilder()

--- a/src/test/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
+++ b/src/test/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
@@ -180,6 +180,21 @@ class DASMockAllTypesTable(maxRows: Int) extends DASTable {
                   .build())
             record.build()
           },
+          "random_record_col" -> {
+            // Generate a random record (with random number of attributes of random names)
+            val record = ValueRecord
+              .newBuilder()
+            (1 to (i % 5)).map { j =>
+              record.addAtts(
+                ValueRecordAttr
+                  .newBuilder()
+                  .setName(s"attr$j")
+                  .setValue(
+                    Value.newBuilder().setString(ValueString.newBuilder().setV(s"random value $j").build()).build())
+                  .build())
+            }
+            Value.newBuilder().setRecord(record.build()).build()
+          },
           "str_record_col" -> {
             val record = Value
               .newBuilder()

--- a/src/test/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
+++ b/src/test/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
@@ -150,6 +150,11 @@ class DASMockAllTypesTable(maxRows: Int) extends DASTable {
                       .newBuilder()
                       .setName("intField")
                       .setValue(Value.newBuilder().setInt(ValueInt.newBuilder().setV(i).build()).build()))
+                  .addAtts(ValueRecordAttr
+                    .newBuilder()
+                    .setName("decimalField")
+                    .setValue(
+                      Value.newBuilder().setDecimal(ValueDecimal.newBuilder().setV(i.toString).build()).build()))
                   .addAtts(
                     ValueRecordAttr
                       .newBuilder()


### PR DESCRIPTION
There is a bug that it gets exposed as HSTORE instead of JSONB. I tested the fix with that. I thought we could keep it.