### PR TITLE
Fixed RD-15501: Pass the gRPC environment to tables and functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val root = (project in file("."))
       // Configuration
       "com.typesafe" % "config" % "1.4.3",
       // Protocol DAS
-      "com.raw-labs" %% "protocol-das" % "1.0.2",
+      "com.raw-labs" %% "protocol-das" % "1.1.0_rc1",
       // Akka Streams
       "org.apache.pekko" %% "pekko-actor-typed" % "1.1.3",
       "org.apache.pekko" %% "pekko-stream" % "1.1.3",
@@ -149,7 +149,7 @@ lazy val root = (project in file("."))
       // Jackson databind
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.2" % Test,
       // gRPC Testing
-      "io.grpc" % "grpc-inprocess" % "1.62.2" % Test,
+      "io.grpc" % "grpc-inprocess" % "1.69.1" % Test,
       // Postgres
       "org.postgresql" % "postgresql" % "42.7.4" % Test,
       // Testing

--- a/src/main/java/com/rawlabs/das/sdk/DASFunction.java
+++ b/src/main/java/com/rawlabs/das/sdk/DASFunction.java
@@ -12,6 +12,7 @@
 
 package com.rawlabs.das.sdk;
 
+import com.rawlabs.protocol.das.v1.common.Environment;
 import com.rawlabs.protocol.das.v1.types.Value;
 import java.util.Map;
 
@@ -24,5 +25,5 @@ public interface DASFunction {
    * @param args a map from argument names to Values
    * @return the computed Value
    */
-  Value execute(Map<String, Value> args);
+  Value execute(Map<String, Value> args, Environment env);
 }

--- a/src/main/java/com/rawlabs/das/sdk/DASTable.java
+++ b/src/main/java/com/rawlabs/das/sdk/DASTable.java
@@ -12,6 +12,7 @@
 
 package com.rawlabs.das.sdk;
 
+import com.rawlabs.protocol.das.v1.common.Environment;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -79,7 +80,11 @@ public interface DASTable {
    * @return a list of explanation lines
    */
   default List<String> explain(
-      List<Qual> quals, List<String> columns, List<SortKey> sortKeys, Long maybeLimit) {
+      List<Qual> quals,
+      List<String> columns,
+      List<SortKey> sortKeys,
+      Long maybeLimit,
+      Environment env) {
     return Collections.emptyList();
   }
 
@@ -92,7 +97,11 @@ public interface DASTable {
    * @return a closeable iterator of rows
    */
   DASExecuteResult execute(
-      List<Qual> quals, List<String> columns, List<SortKey> sortKeys, Long maybeLimit);
+      List<Qual> quals,
+      List<String> columns,
+      List<SortKey> sortKeys,
+      Long maybeLimit,
+      Environment env);
 
   /**
    * Unique column of the table, if any. This is used to identify rows in the table in case of

--- a/src/main/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
+++ b/src/main/scala/com/rawlabs/das/mock/DASMockAllTypesTable.scala
@@ -17,6 +17,7 @@ import java.time.{LocalDate, LocalDateTime, LocalTime}
 import com.google.protobuf.ByteString
 import com.rawlabs.das.sdk.DASExecuteResult
 import com.rawlabs.das.sdk.scala.DASTable
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query._
 import com.rawlabs.protocol.das.v1.tables._
 import com.rawlabs.protocol.das.v1.types._
@@ -31,7 +32,8 @@ class DASMockAllTypesTable(maxRows: Int) extends DASTable {
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): DASExecuteResult = {
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): DASExecuteResult = {
     new DASExecuteResult {
 
       private val iterator = Range(1, maxRows + 1).iterator

--- a/src/main/scala/com/rawlabs/das/mock/DASMockEventTable.scala
+++ b/src/main/scala/com/rawlabs/das/mock/DASMockEventTable.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 
 import com.rawlabs.das.sdk.scala.DASTable
 import com.rawlabs.das.sdk.{DASExecuteResult, DASSdkInvalidArgumentException}
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query.{Operator, Qual, SortKey}
 import com.rawlabs.protocol.das.v1.tables.{Column, Row}
 import com.rawlabs.protocol.das.v1.types.{Value, ValueDate, ValueString}
@@ -52,7 +53,8 @@ class DASMockEventTable extends DASTable with StrictLogging {
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): Seq[String] = {
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): Seq[String] = {
     val dateFilters = extractDateFilters(quals)
     Seq(s"Applying ${dateFilters.size} date filters")
   }
@@ -61,7 +63,8 @@ class DASMockEventTable extends DASTable with StrictLogging {
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): DASExecuteResult = {
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): DASExecuteResult = {
     logger.info(s"Executing query with quals: $quals, columns: $columns, sortKeys: $sortKeys, limit: $maybeLimit")
 
     val dateFilters = extractDateFilters(quals)

--- a/src/main/scala/com/rawlabs/das/mock/DASMockInMemoryTable.scala
+++ b/src/main/scala/com/rawlabs/das/mock/DASMockInMemoryTable.scala
@@ -16,6 +16,7 @@ import scala.jdk.CollectionConverters._
 
 import com.rawlabs.das.sdk.DASExecuteResult
 import com.rawlabs.das.sdk.scala.DASTable
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query.Operator
 import com.rawlabs.protocol.das.v1.query.Qual
 import com.rawlabs.protocol.das.v1.query.SortKey
@@ -53,7 +54,8 @@ class DASMockInMemoryTable(private val dasMockStorage: DASMockStorage) extends D
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): DASExecuteResult = {
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): DASExecuteResult = {
     logger.info(s"Executing query with quals: $quals, columns: $columns, sortKeys: $sortKeys")
 
     new DASExecuteResult {

--- a/src/main/scala/com/rawlabs/das/mock/DASMockTable.scala
+++ b/src/main/scala/com/rawlabs/das/mock/DASMockTable.scala
@@ -14,6 +14,7 @@ package com.rawlabs.das.mock
 
 import com.rawlabs.das.sdk.DASExecuteResult
 import com.rawlabs.das.sdk.scala.DASTable
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query.Qual
 import com.rawlabs.protocol.das.v1.query.SortKey
 import com.rawlabs.protocol.das.v1.tables.Column
@@ -33,7 +34,8 @@ class DASMockTable(maxRows: Int, sleepPerRowMills: Int = 0, breakOnRow: Int = -1
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): Seq[String] = Seq.empty
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): Seq[String] = Seq.empty
 
   /**
    * A SELECT statement is executed by calling the execute method. Quals, colums, sortKeys, limit help to filter,
@@ -58,7 +60,8 @@ class DASMockTable(maxRows: Int, sleepPerRowMills: Int = 0, breakOnRow: Int = -1
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): DASExecuteResult = {
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): DASExecuteResult = {
     logger.info(s"Executing query with quals: $quals, columns: $columns, sortKeys: $sortKeys")
 
     new DASExecuteResult {

--- a/src/main/scala/com/rawlabs/das/mock/functions/AllTypesFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/AllTypesFunction.scala
@@ -15,6 +15,7 @@ package com.rawlabs.das.mock.functions
 import scala.jdk.CollectionConverters.IterableHasAsJava
 
 import com.google.protobuf.ByteString
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
@@ -787,7 +788,7 @@ class AllTypesFunction extends DASMockFunction {
    * @param args a map from argument names to Values
    * @return the computed Value
    */
-  override def execute(args: Map[String, Value]): Value = {
+  override def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     // Returns a record with all the values, using the provided arguments if available.
     val values = recordItems.map { item =>
       val maybeArg = args.get(item.name)

--- a/src/main/scala/com/rawlabs/das/mock/functions/MultiplyIntFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/MultiplyIntFunction.scala
@@ -12,12 +12,13 @@
 
 package com.rawlabs.das.mock.functions
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class MultiplyIntFunction extends DASMockFunction {
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     val x = args("x").getInt.getV
     val y = args("y").getInt.getV
     Value.newBuilder().setInt(ValueInt.newBuilder().setV(x * y)).build()

--- a/src/main/scala/com/rawlabs/das/mock/functions/MultiplyStringFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/MultiplyStringFunction.scala
@@ -12,12 +12,13 @@
 
 package com.rawlabs.das.mock.functions
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class MultiplyStringFunction extends DASMockFunction {
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     val s = args("s").getString.getV
     val n = args("n").getInt.getV
     Value.newBuilder().setString(ValueString.newBuilder().setV(s * n)).build()

--- a/src/main/scala/com/rawlabs/das/mock/functions/NoArgFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/NoArgFunction.scala
@@ -12,12 +12,13 @@
 
 package com.rawlabs.das.mock.functions
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class NoArgFunction extends DASMockFunction {
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     Value.newBuilder().setInt(ValueInt.newBuilder().setV(14)).build()
   }
 

--- a/src/main/scala/com/rawlabs/das/mock/functions/RangeFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/RangeFunction.scala
@@ -13,12 +13,13 @@
 package com.rawlabs.das.mock.functions
 
 import com.rawlabs.das.sdk.DASSdkInvalidArgumentException
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class RangeFunction extends DASMockFunction {
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     if (!args("n").hasInt) {
       throw new DASSdkInvalidArgumentException("The n argument must be a string")
     }

--- a/src/main/scala/com/rawlabs/das/mock/functions/RecipeListOfTypedRecordsFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/RecipeListOfTypedRecordsFunction.scala
@@ -13,6 +13,7 @@
 package com.rawlabs.das.mock.functions
 
 import com.rawlabs.das.sdk.DASSdkInvalidArgumentException
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
@@ -72,7 +73,7 @@ class RecipeListOfTypedRecordsFunction extends DASMockFunction {
       Ingredient("Sour Cream", "30ml"),
       Ingredient("Avocado", "1, sliced")))
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     if (!args("dish").hasString) {
       throw new DASSdkInvalidArgumentException("The dish argument must be a string")
     }

--- a/src/main/scala/com/rawlabs/das/mock/functions/RecordConcatFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/RecordConcatFunction.scala
@@ -12,13 +12,14 @@
 
 package com.rawlabs.das.mock.functions
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class RecordConcatFunction extends DASMockFunction {
 
   /* Concatenates the two records x and y */
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     val x = args("x").getRecord
     val y = args("y").getRecord
     val builder = ValueRecord.newBuilder()

--- a/src/main/scala/com/rawlabs/das/mock/functions/RockAlbumsListOfRecordsWithNestedList.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/RockAlbumsListOfRecordsWithNestedList.scala
@@ -13,6 +13,7 @@
 package com.rawlabs.das.mock.functions
 
 import com.rawlabs.das.sdk.DASSdkInvalidArgumentException
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
@@ -41,7 +42,7 @@ class RockAlbumsListOfRecordsWithNestedList extends DASMockFunction {
    *
    * This function ignores any input arguments and returns a Value containing a list of album records.
    */
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     // Create a builder for a ValueList.
     val listBuilder = ValueList.newBuilder()
     // For each album in our dataset, build a record.

--- a/src/main/scala/com/rawlabs/das/mock/functions/SingleRowPlayerInfoTypedFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/SingleRowPlayerInfoTypedFunction.scala
@@ -12,6 +12,7 @@
 
 package com.rawlabs.das.mock.functions
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
@@ -31,7 +32,7 @@ class SingleRowPlayerInfoTypedFunction extends DASMockFunction {
     BasketballPlayer("Tim Duncan", "San Antonio Spurs", 21, LocalDate.of(1976, 4, 25)),
     BasketballPlayer("Dirk Nowitzki", "Dallas Mavericks", 41, LocalDate.of(1978, 6, 19)))
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     // Extract player's name from the argument "name"
     val name = args("name").getString.getV
 

--- a/src/main/scala/com/rawlabs/das/mock/functions/UnspecifiedRowsFunction.scala
+++ b/src/main/scala/com/rawlabs/das/mock/functions/UnspecifiedRowsFunction.scala
@@ -13,12 +13,13 @@
 package com.rawlabs.das.mock.functions
 
 import com.rawlabs.das.sdk.DASSdkInvalidArgumentException
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.functions.{FunctionDefinition, FunctionId, ParameterDefinition}
 import com.rawlabs.protocol.das.v1.types._
 
 class UnspecifiedRowsFunction extends DASMockFunction {
 
-  def execute(args: Map[String, Value]): Value = {
+  def execute(args: Map[String, Value], maybeEnv: Option[Environment]): Value = {
     if (!args("n").hasInt) {
       throw new DASSdkInvalidArgumentException("The n argument must be an int")
     }

--- a/src/main/scala/com/rawlabs/das/sdk/scala/DASFunction.scala
+++ b/src/main/scala/com/rawlabs/das/sdk/scala/DASFunction.scala
@@ -12,6 +12,7 @@
 
 package com.rawlabs.das.sdk.scala
 
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.types.Value
 
 /**
@@ -25,6 +26,6 @@ trait DASFunction {
    * @param args a map from argument names to Values
    * @return the computed Value
    */
-  def execute(args: Map[String, Value]): Value
+  def execute(args: Map[String, Value], env: Option[Environment]): Value
 
 }

--- a/src/main/scala/com/rawlabs/das/sdk/scala/DASSdkScalaToJavaBridge.scala
+++ b/src/main/scala/com/rawlabs/das/sdk/scala/DASSdkScalaToJavaBridge.scala
@@ -18,6 +18,7 @@ import scala.jdk.CollectionConverters._
 
 import com.rawlabs.das.sdk.DASExecuteResult
 import com.rawlabs.das.sdk.DASTable.TableEstimate
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query.{PathKey, Qual, SortKey}
 import com.rawlabs.protocol.das.v1.tables.Row
 import com.rawlabs.protocol.das.v1.types.Value
@@ -66,20 +67,28 @@ class DASTableScalaToJavaBridge(scalaTable: DASTable) extends com.rawlabs.das.sd
       quals: util.List[Qual],
       columns: util.List[String],
       sortKeys: util.List[SortKey],
-      maybeLimit: java.lang.Long): util.List[String] = scalaTable
-    .explain(quals.asScala.toSeq, columns.asScala.toSeq, sortKeys.asScala.toSeq, Option(maybeLimit).map(_.toLong))
+      maybeLimit: java.lang.Long,
+      env: Environment): util.List[String] = scalaTable
+    .explain(
+      quals.asScala.toSeq,
+      columns.asScala.toSeq,
+      sortKeys.asScala.toSeq,
+      Option(maybeLimit).map(_.toLong),
+      Option(env))
     .asJava
 
   final override def execute(
       quals: util.List[Qual],
       columns: util.List[String],
       sortKeys: util.List[SortKey],
-      maybeLimit: java.lang.Long): DASExecuteResult =
+      maybeLimit: java.lang.Long,
+      env: Environment): DASExecuteResult =
     scalaTable.execute(
       quals.asScala.toSeq,
       columns.asScala.toSeq,
       sortKeys.asScala.toSeq,
-      Option(maybeLimit).map(_.toLong))
+      Option(maybeLimit).map(_.toLong),
+      Option(env))
 
   final override def uniqueColumn: String = scalaTable.uniqueColumn
 
@@ -99,7 +108,7 @@ class DASTableScalaToJavaBridge(scalaTable: DASTable) extends com.rawlabs.das.sd
 
 class DASFunctionScalaToJavaBridge(scalaFunction: DASFunction) extends com.rawlabs.das.sdk.DASFunction {
 
-  final override def execute(args: util.Map[String, Value]): Value =
-    scalaFunction.execute(args.asScala.toMap)
+  final override def execute(args: util.Map[String, Value], env: Environment): Value =
+    scalaFunction.execute(args.asScala.toMap, Option(env))
 
 }

--- a/src/main/scala/com/rawlabs/das/sdk/scala/DASTable.scala
+++ b/src/main/scala/com/rawlabs/das/sdk/scala/DASTable.scala
@@ -12,8 +12,8 @@
 
 package com.rawlabs.das.sdk.scala
 
-import com.rawlabs.das.sdk.DASExecuteResult
-import com.rawlabs.das.sdk.DASSdkUnsupportedException
+import com.rawlabs.das.sdk.{DASExecuteResult, DASSdkUnsupportedException}
+import com.rawlabs.protocol.das.v1.common.Environment
 import com.rawlabs.protocol.das.v1.query.{PathKey, Qual, SortKey}
 import com.rawlabs.protocol.das.v1.tables.Row
 import com.rawlabs.protocol.das.v1.types.Value
@@ -58,7 +58,12 @@ trait DASTable {
    * @param sortKeys sort keys to apply
    * @return a list of explanation lines
    */
-  def explain(quals: Seq[Qual], columns: Seq[String], sortKeys: Seq[SortKey], maybeLimit: Option[Long]): Seq[String] =
+  def explain(
+      quals: Seq[Qual],
+      columns: Seq[String],
+      sortKeys: Seq[SortKey],
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): Seq[String] =
     Seq.empty
 
   /**
@@ -73,7 +78,8 @@ trait DASTable {
       quals: Seq[Qual],
       columns: Seq[String],
       sortKeys: Seq[SortKey],
-      maybeLimit: Option[Long]): DASExecuteResult
+      maybeLimit: Option[Long],
+      maybeEnv: Option[Environment]): DASExecuteResult
 
   /**
    * Unique column of the table, if any. This is used to identify rows in the table in case of update or delete

--- a/src/main/scala/com/rawlabs/das/server/grpc/FunctionServiceGrpcImpl.scala
+++ b/src/main/scala/com/rawlabs/das/server/grpc/FunctionServiceGrpcImpl.scala
@@ -83,7 +83,7 @@ class FunctionServiceGrpcImpl(provider: DASSdkManager)
         }
         .toMap
         .asJava
-      val resultValue = function.execute(sdkArgs)
+      val resultValue = function.execute(sdkArgs, if (request.hasEnv) request.getEnv else null)
 
       val response = ExecuteFunctionResponse.newBuilder().setOutput(resultValue).build()
       responseObserver.onNext(response)


### PR DESCRIPTION
The patch adds the gRPC message `env` to `DASTable.execute`, `DASTable.explain` and `DASFunction.execute`.

The gRPC message specified `env` as optional. So here we make the `DASTable` and `DASFunction` parameters optional (nullable in Java, `Option` in Scala).