### PR TITLE
Switch a couple of logger.debug to logger.info

### DIFF
--- a/src/main/scala/com/rawlabs/das/server/grpc/RegistrationServiceGrpcImpl.scala
+++ b/src/main/scala/com/rawlabs/das/server/grpc/RegistrationServiceGrpcImpl.scala
@@ -44,7 +44,7 @@ class RegistrationServiceGrpcImpl(dasSdkManager: DASSdkManager)
    * @param responseObserver The observer to send responses.
    */
   override def register(request: RegisterRequest, responseObserver: StreamObserver[RegisterResponse]): Unit = {
-    logger.debug(s"Registering DAS with type: ${request.getDefinition.getType}")
+    logger.info(s"Registering DAS with type: ${request.getDefinition.getType}")
     try {
       val dasId = dasSdkManager.registerDAS(
         request.getDefinition.getType,
@@ -52,7 +52,7 @@ class RegistrationServiceGrpcImpl(dasSdkManager: DASSdkManager)
         maybeDasId = if (request.hasId) Some(request.getId) else None)
       responseObserver.onNext(dasId)
       responseObserver.onCompleted()
-      logger.debug(s"DAS registered successfully with ID: $dasId")
+      logger.info(s"DAS registered successfully with ID: $dasId")
     } catch {
       case ex: DASSdkInvalidArgumentException =>
         logger.error("DASSdk invalid argument error", ex)
@@ -80,11 +80,11 @@ class RegistrationServiceGrpcImpl(dasSdkManager: DASSdkManager)
    * @param responseObserver The observer to send responses.
    */
   override def unregister(request: DASId, responseObserver: StreamObserver[UnregisterResponse]): Unit = {
-    logger.debug(s"Unregistering DAS with ID: ${request.getId}")
+    logger.info(s"Unregistering DAS with ID: ${request.getId}")
     dasSdkManager.unregisterDAS(request)
     responseObserver.onNext(UnregisterResponse.newBuilder().build())
     responseObserver.onCompleted()
-    logger.debug(s"DAS unregistered successfully with ID: ${request.getId}")
+    logger.info(s"DAS unregistered successfully with ID: ${request.getId}")
   }
 
 }

--- a/src/main/scala/com/rawlabs/das/server/grpc/TableServiceGrpcImpl.scala
+++ b/src/main/scala/com/rawlabs/das/server/grpc/TableServiceGrpcImpl.scala
@@ -61,7 +61,7 @@ class TableServiceGrpcImpl(
       val response = GetTableDefinitionsResponse.newBuilder().addAllDefinitions(tableDefinitions).build()
       responseObserver.onNext(response)
       responseObserver.onCompleted()
-      logger.debug("Table definitions sent successfully.")
+      logger.info(s"Table definitions (${tableDefinitions.size} tables) sent successfully.")
     }
   }
 
@@ -134,7 +134,7 @@ class TableServiceGrpcImpl(
   override def explainTable(
       request: ExplainTableRequest,
       responseObserver: StreamObserver[ExplainTableResponse]): Unit = {
-    logger.debug(s"Explaining query for Table ID: ${request.getTableId.getName}")
+    logger.info(s"Explaining query for Table ID: ${request.getTableId.getName}")
     withTable(request.getDasId, request.getTableId, responseObserver) { table =>
       val explanation =
         table.explain(
@@ -157,7 +157,7 @@ class TableServiceGrpcImpl(
    * @param responseObserver The observer to send responses.
    */
   override def executeTable(request: ExecuteTableRequest, responseObserver: StreamObserver[Rows]): Unit = {
-    logger.debug(s"Executing query for Table ID: ${request.getTableId.getName}")
+    logger.info(s"Executing query for Table ID: ${request.getTableId.getName}")
 
     // Check if the responseObserver is a ServerCallStreamObserver. If so, we can set an onCancel handler.
     val maybeServerCallObs: Option[ServerCallStreamObserver[Rows]] = responseObserver match {
@@ -293,7 +293,7 @@ class TableServiceGrpcImpl(
     doneF.onComplete {
       case Success(_) =>
         // If it's a normal completion, check if the stream was cancelled
-        logger.debug(s"Streaming completed successfully for planID=${request.getPlanId}.")
+        logger.info(s"Streaming completed successfully for planID=${request.getPlanId}.")
         maybeServerCallObs match {
           case Some(sco) if !sco.isCancelled =>
             sco.onCompleted()
@@ -362,7 +362,7 @@ class TableServiceGrpcImpl(
    * @param responseObserver The observer to send responses.
    */
   override def insertTable(request: InsertTableRequest, responseObserver: StreamObserver[InsertTableResponse]): Unit = {
-    logger.debug(s"Inserting row into Table ID: ${request.getTableId.getName}")
+    logger.info(s"Inserting row into Table ID: ${request.getTableId.getName}")
     withTable(request.getDasId, request.getTableId, responseObserver) { table =>
       val row = table.insert(request.getRow)
       responseObserver.onNext(InsertTableResponse.newBuilder().setRow(row).build())
@@ -380,7 +380,7 @@ class TableServiceGrpcImpl(
   override def bulkInsertTable(
       request: BulkInsertTableRequest,
       responseObserver: StreamObserver[BulkInsertTableResponse]): Unit = {
-    logger.debug(s"Performing bulk insert into Table ID: ${request.getTableId.getName}")
+    logger.info(s"Performing bulk insert into Table ID: ${request.getTableId.getName}")
     withTable(request.getDasId, request.getTableId, responseObserver) { table =>
       val rows = table.bulkInsert(request.getRowsList)
       responseObserver.onNext(BulkInsertTableResponse.newBuilder().addAllRows(rows).build())
@@ -396,7 +396,7 @@ class TableServiceGrpcImpl(
    * @param responseObserver The observer to send responses.
    */
   override def updateTable(request: UpdateTableRequest, responseObserver: StreamObserver[UpdateTableResponse]): Unit = {
-    logger.debug(s"Updating rows in Table ID: ${request.getTableId.getName}")
+    logger.info(s"Updating rows in Table ID: ${request.getTableId.getName}")
     withTable(request.getDasId, request.getTableId, responseObserver) { table =>
       val newRow = table.update(request.getRowId, request.getNewRow)
       responseObserver.onNext(UpdateTableResponse.newBuilder().setRow(newRow).build())
@@ -412,7 +412,7 @@ class TableServiceGrpcImpl(
    * @param responseObserver The observer to send responses.
    */
   override def deleteTable(request: DeleteTableRequest, responseObserver: StreamObserver[DeleteTableResponse]): Unit = {
-    logger.debug(s"Deleting rows from Table ID: ${request.getTableId.getName}")
+    logger.info(s"Deleting rows from Table ID: ${request.getTableId.getName}")
     withTable(request.getDasId, request.getTableId, responseObserver) { table =>
       table.delete(request.getRowId)
       responseObserver.onNext(DeleteTableResponse.getDefaultInstance)

--- a/src/main/scala/com/rawlabs/das/server/manager/DASSdkManager.scala
+++ b/src/main/scala/com/rawlabs/das/server/manager/DASSdkManager.scala
@@ -156,7 +156,7 @@ class DASSdkManager(implicit settings: DASSettings) extends StrictLogging {
           // If no other DAS references this config, invalidate it to trigger a close
           if (!dasSdkConfigCache.values.exists(_ == config)) {
             dasSdkCache.invalidate(config)
-            logger.debug(s"DAS cache invalidated for config of type ${config.dasType}")
+            logger.info(s"DAS cache invalidated for config of type ${config.dasType}")
           }
 
         case None =>
@@ -235,7 +235,7 @@ class DASSdkManager(implicit settings: DASSettings) extends StrictLogging {
               .toMap
 
             ids.put(id, (dasType, options))
-            logger.debug(s"Read DAS configuration for ID: $id, Type: $dasType")
+            logger.info(s"Read DAS configuration for ID: $id, Type: $dasType")
           }
       }
     }
@@ -251,7 +251,7 @@ class DASSdkManager(implicit settings: DASSettings) extends StrictLogging {
     readDASFromConfig().foreach { case (id, (dasType, options)) =>
       val dasId = DASId.newBuilder().setId(id).build()
       registerDAS(dasType, options, Some(dasId))
-      logger.debug(s"Registered DAS from config with ID: $id")
+      logger.info(s"Registered DAS from config with ID: $id")
     }
   }
 


### PR DESCRIPTION
When running with the log level set to `INFO`, the server is almost silent because we only ever emit `DEBUG` or `ERROR` messages. We should change some to `INFO`-level so that when `INFO` is enabled, there’s visible activity in the server logs.